### PR TITLE
use OpenJPEG as name instead of OpenJPEGBuilder

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -2,7 +2,7 @@
 # `julia build_tarballs.jl --help` to see a usage message.
 using BinaryBuilder
 
-name = "OpenJPEGBuilder"
+name = "OpenJPEG"
 version = v"2.3.1"
 
 # Collection of sources required to build OpenJPEGBuilder
@@ -22,8 +22,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_THIRDPARTY:BOOL=ON -DCMAKE_INSTALL_P
 make
 make install
 make clean
-exit
-
 """
 
 # These are the platforms we will build for by default, unless further


### PR DESCRIPTION
This is supposed to represent the project that we are building.

Also removes a superfluous `exit` from the build script.